### PR TITLE
fix: ios17, iphone15 crash

### DIFF
--- a/ios/Parsers/AVCaptureColorSpace+descriptor.swift
+++ b/ios/Parsers/AVCaptureColorSpace+descriptor.swift
@@ -38,7 +38,7 @@ extension AVCaptureColorSpace {
     case .sRGB:
       return "srgb"
     default:
-      fatalError("AVCaptureDevice.Position has unknown state.")
+      return "unknown"
     }
   }
 }

--- a/ios/Parsers/AVCaptureColorSpace+descriptor.swift
+++ b/ios/Parsers/AVCaptureColorSpace+descriptor.swift
@@ -24,6 +24,13 @@ extension AVCaptureColorSpace {
     case "srgb":
       self = .sRGB
       return
+    case "appleLog":
+      if #available(iOS 17, *) {
+        self = .appleLog
+      } else {
+        throw EnumParserError.unsupportedOS(supportedOnOS: "17")
+      }
+      return
     default:
       throw EnumParserError.invalidValue
     }

--- a/ios/Parsers/AVCaptureColorSpace+descriptor.swift
+++ b/ios/Parsers/AVCaptureColorSpace+descriptor.swift
@@ -26,7 +26,7 @@ extension AVCaptureColorSpace {
       return
     case "appleLog":
       if #available(iOS 17, *) {
-        self = .appleLog
+        self = 3
       } else {
         throw EnumParserError.unsupportedOS(supportedOnOS: "17")
       }


### PR DESCRIPTION
## Issues
#### 1. iOS17에서 iPhone15로 `react-native-vision-camera` 사용시 크래시 발생

## References
- issue
=> https://github.com/mrousavy/react-native-vision-camera/issues/1840

- commit
=> https://github.com/mrousavy/react-native-vision-camera/commit/503114b9d1c61d60fa3c69b3bd4cb084758fbf5b

- comment
=> https://github.com/mrousavy/react-native-vision-camera/issues/1840#issuecomment-1733095112